### PR TITLE
feat(S1-4): smoke page statique avec formulaire waitlist Resend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ Full specs in `docs/template-design-specs.md`:
 - **Components:** shadcn/ui copied into project and customized (not used as external dep)
 - **Accessibility:** WCAG 2.1 Level AA, keyboard navigation, ≥4.5:1 contrast
 
+### Frontend Conventions
+
+- **Toasts:** `<Toaster>` is mounted globally in `layout.tsx`. Use `toast()` from `sonner` for system/network errors (API down, service unavailable) and non-field confirmations.
+- **Forms:** Use controlled React state + server actions. Field validation errors (invalid email, required field) → inline `<p>` below the input with `aria-describedby`. System errors (server failure, API error) → `toast.error()`. Success → inline success state when the UI needs to change significantly.
+- **`sr-only`:** Use on labels/headings that are implicit visually but required for screen readers.
+
 ## Planning Artifacts
 
 All specs in `_bmad-output/planning-artifacts/`:

--- a/siana-memento-web/package-lock.json
+++ b/siana-memento-web/package-lock.json
@@ -18,6 +18,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
+        "resend": "^6.9.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -3491,6 +3492,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -6614,6 +6621,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -9458,6 +9471,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
+      "integrity": "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -9932,6 +9951,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.9.2.tgz",
+      "integrity": "sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.3",
+        "svix": "1.84.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -10571,6 +10611,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10870,6 +10920,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.84.1.tgz",
+      "integrity": "sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tagged-tag": {
@@ -11466,6 +11526,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/siana-memento-web/package.json
+++ b/siana-memento-web/package.json
@@ -19,6 +19,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "resend": "^6.9.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/siana-memento-web/src/app/actions.ts
+++ b/siana-memento-web/src/app/actions.ts
@@ -1,37 +1,37 @@
 "use server";
 
-import { Resend } from "resend";
+import {Resend} from "resend";
 
 export type WaitlistResult =
-  | { success: true }
-  | { success: false; error: string };
+    | { success: true }
+    | { success: false; error: string };
 
 export async function subscribeToWaitlist(
-  email: string
+    email: string
 ): Promise<WaitlistResult> {
-  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-    return { success: false, error: "Adresse email invalide." };
-  }
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        return {success: false, error: "Adresse email invalide."};
+    }
 
-  const apiKey = process.env.RESEND_API_KEY;
-  const audienceId = process.env.RESEND_AUDIENCE_ID;
+    const apiKey = process.env.RESEND_API_KEY;
+    const segmentId = process.env.RESEND_SEGMENT_ID;
 
-  if (!apiKey || !audienceId) {
-    console.error("Resend env vars manquantes");
-    return { success: false, error: "Service indisponible. Réessayez plus tard." };
-  }
+    if (!apiKey || !segmentId) {
+        console.error("Resend env vars manquantes");
+        return {success: false, error: "Service indisponible. Réessayez plus tard."};
+    }
 
-  const resend = new Resend(apiKey);
+    const resend = new Resend(apiKey);
 
-  try {
-    await resend.contacts.create({
-      email,
-      audienceId,
-      unsubscribed: false,
-    });
-    return { success: true };
-  } catch (err) {
-    console.error("Resend error:", err);
-    return { success: false, error: "Une erreur est survenue. Réessayez plus tard." };
-  }
+    try {
+        await resend.contacts.create({
+            email,
+            unsubscribed: false,
+            segments: [{id: segmentId}],
+        });
+        return {success: true};
+    } catch (err) {
+        console.error("Resend error:", err);
+        return {success: false, error: "Une erreur est survenue. Réessayez plus tard."};
+    }
 }

--- a/siana-memento-web/src/app/actions.ts
+++ b/siana-memento-web/src/app/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { Resend } from "resend";
+
+export type WaitlistResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export async function subscribeToWaitlist(
+  email: string
+): Promise<WaitlistResult> {
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return { success: false, error: "Adresse email invalide." };
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const audienceId = process.env.RESEND_AUDIENCE_ID;
+
+  if (!apiKey || !audienceId) {
+    console.error("Resend env vars manquantes");
+    return { success: false, error: "Service indisponible. Réessayez plus tard." };
+  }
+
+  const resend = new Resend(apiKey);
+
+  try {
+    await resend.contacts.create({
+      email,
+      audienceId,
+      unsubscribed: false,
+    });
+    return { success: true };
+  } catch (err) {
+    console.error("Resend error:", err);
+    return { success: false, error: "Une erreur est survenue. Réessayez plus tard." };
+  }
+}

--- a/siana-memento-web/src/app/layout.tsx
+++ b/siana-memento-web/src/app/layout.tsx
@@ -2,10 +2,37 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/siana/ThemeProvider";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://siana-memento.com";
+
 export const metadata: Metadata = {
   title: "Siana Memento — Save the Date en 15 minutes",
   description:
     "Créez votre faire-part de mariage personnalisé par IA en 15 minutes. Designs uniques à partir de vos photos. À partir de 19,90€.",
+  openGraph: {
+    title: "Siana Memento — Save the Date en 15 minutes",
+    description:
+      "Créez votre faire-part de mariage personnalisé par IA en 15 minutes. Designs uniques à partir de vos photos. À partir de 19,90€.",
+    url: siteUrl,
+    siteName: "Siana Memento",
+    images: [
+      {
+        url: `${siteUrl}/og-image.jpg`,
+        width: 1200,
+        height: 630,
+        alt: "Siana Memento — Save the Date personnalisé par IA",
+      },
+    ],
+    locale: "fr_FR",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Siana Memento — Save the Date en 15 minutes",
+    description:
+      "Créez votre faire-part de mariage personnalisé par IA en 15 minutes. À partir de 19,90€.",
+    images: [`${siteUrl}/og-image.jpg`],
+  },
+  metadataBase: new URL(siteUrl),
 };
 
 export default function RootLayout({

--- a/siana-memento-web/src/app/layout.tsx
+++ b/siana-memento-web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/siana/ThemeProvider";
+import { Toaster } from "@/components/ui/sonner";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://siana-memento.com";
 
@@ -43,7 +44,10 @@ export default function RootLayout({
   return (
     <html lang="fr" suppressHydrationWarning>
       <body className="antialiased">
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          {children}
+          <Toaster richColors position="bottom-center" />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/siana-memento-web/src/app/page.tsx
+++ b/siana-memento-web/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
             Bientôt disponible
           </span>
 
-          <h1 className="font-display text-5xl font-bold leading-tight tracking-tight text-foreground sm:text-6xl md:text-7xl">
+          <h1 className="text-5xl font-bold leading-tight tracking-tight text-foreground sm:text-6xl md:text-7xl">
             Siana&nbsp;
             <span className="text-primary">Memento</span>
           </h1>
@@ -44,9 +44,9 @@ export default function Home() {
 
         {/* Pricing */}
         <div className="mb-12 flex items-baseline gap-1.5">
-          <span className="font-display text-5xl font-bold text-foreground">
+          <h2 className="text-5xl font-bold text-foreground">
             19,90&nbsp;€
-          </span>
+          </h2>
           <span className="text-base text-muted-foreground">par design</span>
         </div>
 
@@ -61,12 +61,12 @@ export default function Home() {
             { n: "3", label: "L'IA crée votre design" },
           ].map(({ n, label }) => (
             <li key={n} className="flex items-center gap-3 text-sm text-muted-foreground">
-              <span
+              <h3
                 className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground"
                 aria-hidden="true"
               >
                 {n}
-              </span>
+              </h3>
               {label}
             </li>
           ))}

--- a/siana-memento-web/src/app/page.tsx
+++ b/siana-memento-web/src/app/page.tsx
@@ -1,65 +1,99 @@
-import Image from "next/image";
+import WaitlistForm from "@/components/siana/WaitlistForm";
+import { ThemeToggle } from "@/components/siana/ThemeToggle";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+    <div className="relative min-h-screen overflow-hidden bg-background">
+      {/* Botanical background blobs */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+      >
+        <div className="absolute -top-32 -right-32 h-[600px] w-[600px] rounded-full bg-[#2d4a3e]/8 blur-3xl dark:bg-[#2d4a3e]/20" />
+        <div className="absolute -bottom-32 -left-32 h-[500px] w-[500px] rounded-full bg-[#b5c4b1]/20 blur-3xl dark:bg-[#2d4a3e]/15" />
+        <div className="absolute top-1/2 left-1/2 h-[400px] w-[400px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#f5efe6]/40 blur-3xl dark:bg-[#1e2d26]/40" />
+      </div>
+
+      {/* Theme toggle */}
+      <header className="relative z-10 flex justify-end p-4 sm:p-6">
+        <ThemeToggle />
+      </header>
+
+      {/* Main content */}
+      <main
+        id="main-content"
+        className="relative z-10 flex min-h-[calc(100vh-80px)] flex-col items-center justify-center px-6 pb-16 text-center"
+      >
+        {/* Brand + badge */}
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <span className="inline-block rounded-full border border-primary/20 bg-primary/8 px-4 py-1.5 text-xs font-semibold tracking-[0.15em] uppercase text-primary dark:bg-primary/15">
+            Bientôt disponible
+          </span>
+
+          <h1 className="font-display text-5xl font-bold leading-tight tracking-tight text-foreground sm:text-6xl md:text-7xl">
+            Siana&nbsp;
+            <span className="text-primary">Memento</span>
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+        </div>
+
+        {/* Value proposition */}
+        <p className="mx-auto mb-6 max-w-xl text-xl leading-relaxed text-muted-foreground sm:text-2xl">
+          Générez votre Save the Date unique avec vos photos en{" "}
+          <strong className="font-semibold text-foreground">15 minutes</strong>
+        </p>
+
+        {/* Pricing */}
+        <div className="mb-12 flex items-baseline gap-1.5">
+          <span className="font-display text-5xl font-bold text-foreground">
+            19,90&nbsp;€
+          </span>
+          <span className="text-base text-muted-foreground">par design</span>
+        </div>
+
+        {/* How it works — 3 steps */}
+        <ol
+          aria-label="Comment ça marche"
+          className="mb-12 flex flex-col items-center gap-4 sm:flex-row sm:gap-8"
+        >
+          {[
+            { n: "1", label: "Uploadez vos photos" },
+            { n: "2", label: "Choisissez un style" },
+            { n: "3", label: "L'IA crée votre design" },
+          ].map(({ n, label }) => (
+            <li key={n} className="flex items-center gap-3 text-sm text-muted-foreground">
+              <span
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground"
+                aria-hidden="true"
+              >
+                {n}
+              </span>
+              {label}
+            </li>
+          ))}
+        </ol>
+
+        {/* Waitlist form */}
+        <section
+          aria-labelledby="waitlist-heading"
+          className="w-full max-w-lg"
+        >
+          <h2 id="waitlist-heading" className="sr-only">
+            Rejoindre la liste d&rsquo;attente
+          </h2>
+          <WaitlistForm />
+          <p className="mt-3 text-xs text-muted-foreground">
+            Aucun spam. Notification de lancement uniquement. Données supprimées
+            sur demande.
           </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+        </section>
       </main>
+
+      {/* Footer */}
+      <footer className="relative z-10 pb-6 text-center">
+        <p className="text-xs text-muted-foreground">
+          © 2026 Siana Memento · Fait avec soin en France
+        </p>
+      </footer>
     </div>
   );
 }

--- a/siana-memento-web/src/components/siana/WaitlistForm.tsx
+++ b/siana-memento-web/src/components/siana/WaitlistForm.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { subscribeToWaitlist } from "@/app/actions";
+
+export default function WaitlistForm() {
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus("loading");
+    setErrorMsg("");
+
+    const result = await subscribeToWaitlist(email);
+
+    if (result.success) {
+      setStatus("success");
+      setEmail("");
+    } else {
+      setStatus("error");
+      setErrorMsg(result.error);
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex flex-col items-center gap-2 py-4 text-center"
+      >
+        <span className="text-2xl" aria-hidden="true">🌿</span>
+        <p className="font-display text-lg font-semibold text-foreground">
+          Vous êtes sur la liste&nbsp;!
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Nous vous préviendrons dès le lancement de Siana Memento.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex w-full flex-col gap-3 sm:flex-row"
+      noValidate
+    >
+      <label htmlFor="waitlist-email" className="sr-only">
+        Adresse email
+      </label>
+      <Input
+        id="waitlist-email"
+        type="email"
+        placeholder="votre@email.fr"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        disabled={status === "loading"}
+        aria-describedby={status === "error" ? "waitlist-error" : undefined}
+        aria-invalid={status === "error"}
+        className="h-11 flex-1 bg-white/80 text-foreground placeholder:text-muted-foreground/60 backdrop-blur-sm"
+      />
+      <Button
+        type="submit"
+        disabled={status === "loading" || !email}
+        size="lg"
+        className="h-11 shrink-0 px-8 font-semibold"
+      >
+        {status === "loading" ? "Inscription…" : "Rejoindre la liste"}
+      </Button>
+      {status === "error" && (
+        <p
+          id="waitlist-error"
+          role="alert"
+          aria-live="assertive"
+          className="w-full text-center text-sm text-destructive sm:text-left"
+        >
+          {errorMsg}
+        </p>
+      )}
+    </form>
+  );
+}

--- a/siana-memento-web/src/components/siana/WaitlistForm.tsx
+++ b/siana-memento-web/src/components/siana/WaitlistForm.tsx
@@ -1,88 +1,96 @@
 "use client";
 
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { subscribeToWaitlist } from "@/app/actions";
+import React, {useState} from "react";
+import {toast} from "sonner";
+import {Button} from "@/components/ui/button";
+import {Input} from "@/components/ui/input";
+import {subscribeToWaitlist} from "@/app/actions";
 
 export default function WaitlistForm() {
-  const [email, setEmail] = useState("");
-  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [errorMsg, setErrorMsg] = useState("");
+    const [email, setEmail] = useState("");
+    const [status, setStatus] = useState<"idle" | "loading" | "success">("idle");
+    const [fieldError, setFieldError] = useState("");
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setStatus("loading");
-    setErrorMsg("");
+    async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setFieldError("");
 
-    const result = await subscribeToWaitlist(email);
+        if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            setFieldError("Adresse email invalide.");
+            return;
+        }
 
-    if (result.success) {
-      setStatus("success");
-      setEmail("");
-    } else {
-      setStatus("error");
-      setErrorMsg(result.error);
+        setStatus("loading");
+        const result = await subscribeToWaitlist(email);
+
+        if (result.success) {
+            setStatus("success");
+            setEmail("");
+        } else {
+            setStatus("idle");
+            toast.error(result.error, {
+                position: 'top-right'
+            });
+        }
     }
-  }
 
-  if (status === "success") {
+    if (status === "success") {
+        return (
+            <div
+                role="status"
+                aria-live="polite"
+                className="flex flex-col items-center gap-2 py-4 text-center"
+            >
+                <span className="text-2xl" aria-hidden="true">🌿</span>
+                <p className="font-display text-lg font-semibold text-foreground">
+                    Vous êtes sur la liste&nbsp;!
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    Nous vous préviendrons dès le lancement de Siana Memento.
+                </p>
+            </div>
+        );
+    }
+
     return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="flex flex-col items-center gap-2 py-4 text-center"
-      >
-        <span className="text-2xl" aria-hidden="true">🌿</span>
-        <p className="font-display text-lg font-semibold text-foreground">
-          Vous êtes sur la liste&nbsp;!
-        </p>
-        <p className="text-sm text-muted-foreground">
-          Nous vous préviendrons dès le lancement de Siana Memento.
-        </p>
-      </div>
+        <form onSubmit={handleSubmit} className="flex w-full flex-col gap-2" noValidate>
+            <div className="flex w-full flex-col gap-3 sm:flex-row">
+                <label htmlFor="waitlist-email" className="sr-only">
+                    Adresse email
+                </label>
+                <Input
+                    id="waitlist-email"
+                    type="email"
+                    placeholder="votre@email.fr"
+                    value={email}
+                    onChange={(e) => {
+                        setEmail(e.target.value);
+                        if (fieldError) setFieldError("");
+                    }}
+                    required
+                    disabled={status === "loading"}
+                    aria-describedby={fieldError ? "waitlist-field-error" : undefined}
+                    aria-invalid={!!fieldError}
+                    className="h-11 flex-1 bg-white/80 text-foreground placeholder:text-muted-foreground/60 backdrop-blur-sm"
+                />
+                <Button
+                    type="submit"
+                    disabled={status === "loading" || !email}
+                    size="lg"
+                    className="h-11 shrink-0 px-8 font-semibold"
+                >
+                    {status === "loading" ? "Inscription…" : "Rejoindre la liste"}
+                </Button>
+            </div>
+            {fieldError && (
+                <p
+                    id="waitlist-field-error"
+                    role="alert"
+                    className="text-sm text-destructive"
+                >
+                    {fieldError}
+                </p>
+            )}
+        </form>
     );
-  }
-
-  return (
-    <form
-      onSubmit={handleSubmit}
-      className="flex w-full flex-col gap-3 sm:flex-row"
-      noValidate
-    >
-      <label htmlFor="waitlist-email" className="sr-only">
-        Adresse email
-      </label>
-      <Input
-        id="waitlist-email"
-        type="email"
-        placeholder="votre@email.fr"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-        disabled={status === "loading"}
-        aria-describedby={status === "error" ? "waitlist-error" : undefined}
-        aria-invalid={status === "error"}
-        className="h-11 flex-1 bg-white/80 text-foreground placeholder:text-muted-foreground/60 backdrop-blur-sm"
-      />
-      <Button
-        type="submit"
-        disabled={status === "loading" || !email}
-        size="lg"
-        className="h-11 shrink-0 px-8 font-semibold"
-      >
-        {status === "loading" ? "Inscription…" : "Rejoindre la liste"}
-      </Button>
-      {status === "error" && (
-        <p
-          id="waitlist-error"
-          role="alert"
-          aria-live="assertive"
-          className="w-full text-center text-sm text-destructive sm:text-left"
-        >
-          {errorMsg}
-        </p>
-      )}
-    </form>
-  );
 }


### PR DESCRIPTION
## Summary
- Closes #4
- Remplace le placeholder Next.js par la smoke page de lancement : titre, sous-titre, pricing 19,90 €, formulaire waitlist
- Intègre Resend pour enregistrer les emails dans une audience (server action sécurisée)
- Ajoute les meta tags complets : title, description, og:title, og:description, og:image, Twitter Card

## Test plan
- [x] La page racine affiche "Siana Memento", le sous-titre exact, et "19,90 €"
- [x] Soumettre un email valide → message de confirmation s'affiche
- [x] Soumettre un email invalide → message d'erreur s'affiche
- [x] L'email apparaît dans l'audience Resend (vérifier avec `RESEND_API_KEY` + `RESEND_AUDIENCE_ID` dans `.env.local`)
- [x] Inspecter `<head>` : présence de `og:title`, `og:description`, `og:image`
- [x] Lighthouse mobile : Performance ≥ 90, SEO ≥ 95, Accessibility ≥ 90