### PR TITLE
feat(S3-5): révélation du design avec effet wow

### DIFF
--- a/_bmad-output/implementation-artifacts/3-5-revelation-du-design-avec-effet-wow.md
+++ b/_bmad-output/implementation-artifacts/3-5-revelation-du-design-avec-effet-wow.md
@@ -1,6 +1,6 @@
 # Story 3.5 : Révélation du Design avec Effet Wow
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -294,6 +294,13 @@ afin de vivre le moment émotionnel fort qui est au cœur de l'expérience Siana
 - [x] Task 5 : Vérification qualité (AC: ensemble)
   - [x] `npx tsc --noEmit` depuis `siana-memento-web/` — zéro erreur TypeScript
   - [x] `npx eslint src/components/siana/ResultGuard.tsx src/components/siana/ResultView.tsx src/app/\(public\)/generate/result/page.tsx` — zéro warning ESLint
+
+### Review Follow-ups (AI)
+
+- [ ] [AI-Review][High] Story File List non vérifiable : Git ne montre aucun changement alors que 5 fichiers sont revendiqués. Corriger la liste ou fournir les diff réels.
+- [ ] [AI-Review][High] AC #2 : la modal doit inclure un bouton de fermeture explicite. Ajouter un bouton "Fermer" (DialogClose).
+- [ ] [AI-Review][Medium] Accessibilité clavier : gérer aussi la touche Espace sur l’illustration (role=button).
+- [ ] [AI-Review][Medium] Nettoyer le `setTimeout` des confettis pour éviter un déclenchement après un unmount rapide.
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/3-5-revelation-du-design-avec-effet-wow.md
+++ b/_bmad-output/implementation-artifacts/3-5-revelation-du-design-avec-effet-wow.md
@@ -1,0 +1,522 @@
+# Story 3.5 : Révélation du Design avec Effet Wow
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+En tant qu'utilisateur,
+je veux découvrir mon illustration générée via une révélation animée,
+afin de vivre le moment émotionnel fort qui est au cœur de l'expérience Siana Memento.
+
+## Acceptance Criteria
+
+1. **Given** la génération terminée avec succès **When** l'utilisateur arrive sur `/generate/result` **Then** l'illustration apparaît via un fade-in progressif sur 2 secondes suivi d'une célébration confettis de 3 secondes (canvas-confetti, ~3KB gzip) (FR14)
+
+2. **Given** l'illustration révélée **When** l'utilisateur clique sur l'illustration **Then** une modal s'ouvre affichant l'image en pleine résolution avec un bouton de fermeture (FR15)
+
+3. **Given** l'illustration révélée sur mobile **When** l'utilisateur fait un pinch-to-zoom **Then** le navigateur permet le zoom natif sur la zone image via CSS `touch-action: pinch-zoom` (FR15)
+
+4. **Given** l'illustration affichée **When** l'utilisateur consulte l'interface **Then** le compteur d'itérations est visible sous l'image ("Itération 1/3 — 2 itérations restantes incluses") avec la valeur correcte depuis le store (FR16)
+
+5. **Given** un utilisateur arrivant sur `/generate/result` sans `generatedImageUrl` ou sans `designId` dans le store **When** la page se charge après hydratation **Then** il est redirigé automatiquement vers `/generate/generating`
+
+6. **Given** l'illustration affichée **When** l'utilisateur consulte la page **Then** la mascotte `siana-success.svg` est visible avec un message de félicitations (état de succès)
+
+## Tasks / Subtasks
+
+### Installation de la dépendance canvas-confetti
+
+- [x] Task 1 : Installer `canvas-confetti` dans `siana-memento-web/` (AC: #1)
+  - [x] Depuis le dossier `siana-memento-web/` :
+    ```bash
+    npm install canvas-confetti
+    npm install -D @types/canvas-confetti
+    ```
+  - [x] Vérifier dans `package.json` que les deux dépendances apparaissent
+
+### Frontend — Composant ResultGuard
+
+- [x] Task 2 : Créer `siana-memento-web/src/components/siana/ResultGuard.tsx` (AC: #5)
+  - [x] Pattern identique aux autres Guards (`GeneratingGuard`, `ConfigureGuard`, `TemplateGuard`) :
+    ```tsx
+    'use client'
+
+    import { useEffect } from 'react'
+    import { useRouter } from 'next/navigation'
+    import { useGenerationStore } from '@/stores/useGenerationStore'
+
+    interface ResultGuardProps {
+      children: React.ReactNode
+    }
+
+    export default function ResultGuard({ children }: ResultGuardProps) {
+      const router = useRouter()
+      const { designId, generatedImageUrl, _hasHydrated } = useGenerationStore()
+
+      useEffect(() => {
+        if (!_hasHydrated) return
+        if (!designId || !generatedImageUrl) {
+          router.replace('/generate/generating')
+        }
+      }, [_hasHydrated, designId, generatedImageUrl, router])
+
+      if (!_hasHydrated || !designId || !generatedImageUrl) return null
+
+      return <>{children}</>
+    }
+    ```
+
+### Frontend — Composant ResultView
+
+- [x] Task 3 : Créer `siana-memento-web/src/components/siana/ResultView.tsx` (AC: #1, #2, #3, #4, #6)
+
+  **Logique globale :**
+  1. Au montage → déclencher le fade-in CSS sur l'image (classe CSS `opacity-0` → `opacity-100` transition 2s)
+  2. Après 500ms (image commence à apparaître) → lancer les confettis `canvas-confetti` (burst de 3s)
+  3. Clic sur l'image → ouvrir `<Dialog>` shadcn avec l'image en taille réelle
+  4. Afficher compteur d'itérations (`iterationsUsed` du store)
+  5. Mascotte `siana-success.svg` + message de félicitations
+
+  **Implémentation :**
+  ```tsx
+  'use client'
+
+  import { useEffect, useRef, useState } from 'react'
+  import Image from 'next/image'
+  import { Button } from '@/components/ui/button'
+  import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    DialogClose,
+  } from '@/components/ui/dialog'
+  import { useGenerationStore } from '@/stores/useGenerationStore'
+  import confetti from 'canvas-confetti'
+
+  const MAX_ITERATIONS = 3
+
+  export default function ResultView() {
+    const { generatedImageUrl, partner1Name, partner2Name, iterationsUsed } = useGenerationStore()
+    const [isRevealed, setIsRevealed] = useState(false)
+    const [isModalOpen, setIsModalOpen] = useState(false)
+    const confettiFiredRef = useRef(false)
+
+    // Fade-in de l'image + lancement des confettis
+    useEffect(() => {
+      // Petite pause pour laisser le DOM se stabiliser
+      const revealTimer = setTimeout(() => {
+        setIsRevealed(true)
+
+        // Lancer les confettis après 300ms (image commence à apparaître)
+        if (!confettiFiredRef.current) {
+          confettiFiredRef.current = true
+          const end = Date.now() + 3000 // 3 secondes de confettis
+
+          const launchConfetti = () => {
+            confetti({
+              particleCount: 3,
+              angle: 60,
+              spread: 55,
+              origin: { x: 0 },
+              colors: ['#2D4A3E', '#C17A6F', '#D4AF37'],
+            })
+            confetti({
+              particleCount: 3,
+              angle: 120,
+              spread: 55,
+              origin: { x: 1 },
+              colors: ['#2D4A3E', '#C17A6F', '#D4AF37'],
+            })
+            if (Date.now() < end) {
+              requestAnimationFrame(launchConfetti)
+            }
+          }
+
+          setTimeout(launchConfetti, 300)
+        }
+      }, 100)
+
+      return () => clearTimeout(revealTimer)
+    }, [])
+
+    const remainingIterations = MAX_ITERATIONS - iterationsUsed
+    const iterationLabel =
+      remainingIterations > 0
+        ? `Itération ${iterationsUsed}/${MAX_ITERATIONS} — ${remainingIterations} itération${remainingIterations > 1 ? 's' : ''} restante${remainingIterations > 1 ? 's' : ''} incluse${remainingIterations > 1 ? 's' : ''}`
+        : `Itération ${iterationsUsed}/${MAX_ITERATIONS} — Aucune itération restante`
+
+    return (
+      <div className="flex flex-col items-center gap-6 py-8">
+        {/* Mascotte + message de félicitations */}
+        <div className="flex flex-col items-center gap-3">
+          <Image
+            src="/mascotte/siana-success.svg"
+            alt=""
+            aria-hidden="true"
+            width={72}
+            height={72}
+          />
+          <div className="text-center">
+            <h1 className="text-2xl font-bold">Votre Save the Date est prêt !</h1>
+            {partner1Name && partner2Name && (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {partner1Name} &amp; {partner2Name}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Illustration avec fade-in et comportement zoom */}
+        <div
+          className={[
+            'w-full overflow-hidden rounded-2xl shadow-2xl cursor-zoom-in',
+            'transition-opacity duration-[2000ms] ease-in-out',
+            isRevealed ? 'opacity-100' : 'opacity-0',
+          ].join(' ')}
+          style={{ touchAction: 'pinch-zoom' }}
+          onClick={() => setIsModalOpen(true)}
+          onKeyDown={(e) => e.key === 'Enter' && setIsModalOpen(true)}
+          role="button"
+          tabIndex={0}
+          aria-label="Voir l'illustration en plein écran"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={generatedImageUrl!}
+            alt={`Illustration Save the Date pour ${partner1Name ?? ''} et ${partner2Name ?? ''}`}
+            className="w-full h-auto object-contain"
+          />
+        </div>
+
+        {/* Compteur d'itérations */}
+        <p className="text-sm text-muted-foreground text-center" aria-live="polite">
+          {iterationLabel}
+        </p>
+
+        {/* Actions */}
+        <div className="flex w-full flex-col gap-3">
+          {remainingIterations > 0 ? (
+            <Button
+              size="lg"
+              variant="outline"
+              className="w-full font-semibold"
+              onClick={() => {
+                // Story 3.6 — Itérations et Feedback Simple
+                // TODO: Naviguer vers le panneau de feedback (Story 3.6)
+                // router.push('/generate/iterate') ou ouvrir un panneau slide
+                alert('Itérations disponibles en Story 3.6')
+              }}
+            >
+              Ajuster mon illustration
+            </Button>
+          ) : (
+            <Button size="lg" variant="outline" className="w-full" disabled>
+              Limite de 3 itérations atteinte
+            </Button>
+          )}
+          <Button
+            size="lg"
+            className="w-full font-semibold"
+            onClick={() => {
+              // Story 4.1 — Checkout Stripe
+              // TODO: Naviguer vers le checkout
+              alert('Paiement disponible en Story 4.1')
+            }}
+          >
+            Commander mon poster — 19,90 €
+          </Button>
+        </div>
+
+        {/* Dialog plein écran pour zoom */}
+        <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+          <DialogContent
+            className="max-w-[95vw] max-h-[95vh] p-2 overflow-auto"
+            aria-describedby={undefined}
+          >
+            <DialogTitle className="sr-only">
+              Illustration Save the Date — Vue plein écran
+            </DialogTitle>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={generatedImageUrl!}
+              alt={`Illustration Save the Date pour ${partner1Name ?? ''} et ${partner2Name ?? ''}`}
+              className="w-full h-auto object-contain"
+              style={{ touchAction: 'pinch-zoom' }}
+            />
+            <DialogClose asChild>
+              <Button
+                variant="outline"
+                className="mt-2 w-full"
+                aria-label="Fermer la vue plein écran"
+              >
+                Fermer
+              </Button>
+            </DialogClose>
+          </DialogContent>
+        </Dialog>
+      </div>
+    )
+  }
+  ```
+
+### Frontend — Page `/generate/result`
+
+- [x] Task 4 : Remplacer le stub de `siana-memento-web/src/app/(public)/generate/result/page.tsx` (AC: #1–#6)
+  - [x] Supprimer tout le contenu actuel (stub Story 3.4)
+  - [x] Remplacer par :
+    ```tsx
+    import type { Metadata } from 'next'
+    import ResultGuard from '@/components/siana/ResultGuard'
+    import ResultView from '@/components/siana/ResultView'
+
+    export const metadata: Metadata = {
+      title: 'Votre Save the Date — Siana Memento',
+    }
+
+    export default function ResultPage() {
+      return (
+        <main className="flex min-h-screen flex-col items-center justify-start px-4 py-8">
+          <div className="w-full max-w-lg">
+            <ResultGuard>
+              <ResultView />
+            </ResultGuard>
+          </div>
+        </main>
+      )
+    }
+    ```
+  - **Note :** La page Server Component (`import type { Metadata }`) wrap les Client Components `ResultGuard` + `ResultView`. Pattern identique aux pages generating, configure, upload.
+
+### Vérification TypeScript et ESLint
+
+- [x] Task 5 : Vérification qualité (AC: ensemble)
+  - [x] `npx tsc --noEmit` depuis `siana-memento-web/` — zéro erreur TypeScript
+  - [x] `npx eslint src/components/siana/ResultGuard.tsx src/components/siana/ResultView.tsx src/app/\(public\)/generate/result/page.tsx` — zéro warning ESLint
+
+## Dev Notes
+
+### Architecture globale de la Story 3.5
+
+```
+Flux utilisateur Story 3.5 :
+
+1. GeneratingView (Story 3.4) → progress 100% → setGenerationResult(iterationsUsed, imageUrl)
+   → setStep('result') → router.push('/generate/result')
+
+2. ResultPage charge → ResultGuard vérifie designId + generatedImageUrl dans Zustand
+   - Pas de designId ou generatedImageUrl → redirect /generate/generating
+   - OK → render ResultView
+
+3. ResultView monte :
+   a. setTimeout(100ms) → setIsRevealed(true) → CSS opacity-0 → opacity-100 (transition 2s)
+   b. setTimeout(400ms) → lancer canvas-confetti (3s, côté gauche + droit, couleurs brand)
+   c. L'utilisateur peut cliquer l'image → Dialog plein écran
+   d. Le compteur d'itérations s'affiche (depuis store.iterationsUsed)
+```
+
+### Données disponibles dans le Zustand store
+
+Depuis `useGenerationStore`, les champs suivants sont disponibles après Story 3.4 :
+
+```typescript
+generatedImageUrl: string | null  // data:image/png;base64,... (base64 data URL, peut être 5-15MB)
+iterationsUsed: number            // 1 après première génération
+designId: number | null           // ID du design côté backend
+partner1Name: string | null       // Nom du/de la premier(ère) marié(e)
+partner2Name: string | null       // Nom du/de la second(e) marié(e)
+_hasHydrated: boolean             // true après réhydratation Zustand persist
+```
+
+**CRITIQUE :** `generatedImageUrl` est un base64 data URL (ex: `data:image/png;base64,iVBORw0KGgo...`). Utiliser `<img src={generatedImageUrl} />` (balise native, PAS `next/image`) car `next/image` ne supporte pas les data URLs. Ce pattern est déjà en place dans le stub actuel.
+
+**Note :** `setGenerationResult()` dans `GeneratingView.tsx` (Task 11 Story 3.4) est appelé avec le `generatedImageUrl` retourné par `triggerGeneration()`. Vérifier que `triggerGeneration()` retourne bien le `generatedImageUrl` (voir `lib/api/designs.ts` — la réponse backend contient le champ).
+
+### canvas-confetti — Configuration et couleurs brand
+
+**Package :** `canvas-confetti@^1.9.x` (version stable, ~3KB gzip)
+**Types :** `@types/canvas-confetti` en devDependency
+
+**Import :** `import confetti from 'canvas-confetti'`
+
+**Couleurs brand Siana Memento :**
+- `#2D4A3E` — Sage Green (accent principal)
+- `#C17A6F` — Terracotta (template Bohème, couleur chaleur)
+- `#D4AF37` — Gold (accent élégance)
+
+**Pattern confetti recommandé (burst des deux côtés) :**
+```typescript
+const end = Date.now() + 3000
+const launchConfetti = () => {
+  confetti({ particleCount: 3, angle: 60, spread: 55, origin: { x: 0 }, colors: ['#2D4A3E', '#C17A6F', '#D4AF37'] })
+  confetti({ particleCount: 3, angle: 120, spread: 55, origin: { x: 1 }, colors: ['#2D4A3E', '#C17A6F', '#D4AF37'] })
+  if (Date.now() < end) requestAnimationFrame(launchConfetti)
+}
+setTimeout(launchConfetti, 300)
+```
+
+**Protection double déclenchement (React Strict Mode) :** Utiliser une `ref` `confettiFiredRef` (identique au pattern `hasStarted` de Story 3.4) pour éviter un double lancement en dev.
+
+**canvas-confetti et SSR :** Le package nécessite `window` — s'assurer que le composant est `'use client'`. Avec Next.js 16, les composants marqués `'use client'` ne s'exécutent pas côté serveur, donc pas de souci particulier.
+
+### Fade-in CSS — Approche recommandée
+
+Utiliser la transition CSS Tailwind avec durée personnalisée :
+
+```tsx
+// Classe Tailwind v4 — durée arbitraire avec brackets
+className={[
+  'transition-opacity duration-[2000ms] ease-in-out',
+  isRevealed ? 'opacity-100' : 'opacity-0'
+].join(' ')}
+```
+
+**Tailwind v4 :** Le projet utilise Tailwind CSS v4 (`"tailwindcss": "^4"`). Les valeurs arbitraires avec `[...]` sont supportées nativement. `tw-animate-css` est également disponible en devDependency si des animations plus complexes sont nécessaires.
+
+**Timing :**
+- `setTimeout(100ms)` avant de setIsRevealed → laisse le DOM se stabiliser au montage
+- `transition-opacity duration-[2000ms]` → fade-in 2 secondes (AC #1)
+- Confettis démarrent à +300ms (image à ~15% du fade-in, visible mais pas encore complète)
+
+### Pinch-to-zoom — Approche CSS native (sans library JS)
+
+**Sur mobile :** `style={{ touchAction: 'pinch-zoom' }}` sur le conteneur image permet au navigateur de gérer nativement le zoom via gesture. Pas de JS supplémentaire. Fonctionne sur iOS Safari et Chrome Android.
+
+**Sur desktop :** Clic sur l'image → Dialog modal avec image plein écran (AC #2). L'utilisateur peut zoomer avec Ctrl+scroll dans le navigateur.
+
+**Pas de library de zoom JS** (medium-zoom, photoswipe, etc.) pour le MVP — trop lourd. La combinaison CSS `touch-action: pinch-zoom` + Dialog shadcn est suffisante pour l'AC #2 et #3.
+
+### Compteur d'itérations — Logique
+
+```typescript
+const MAX_ITERATIONS = 3
+const remainingIterations = MAX_ITERATIONS - iterationsUsed
+
+// Exemples :
+// iterationsUsed = 1 → "Itération 1/3 — 2 itérations restantes incluses"
+// iterationsUsed = 2 → "Itération 2/3 — 1 itération restante incluse"
+// iterationsUsed = 3 → "Itération 3/3 — Aucune itération restante"
+```
+
+**`iterationsUsed` dans le store** est mis à jour par `setGenerationResult(result.iterationsUsed, ...)` dans `GeneratingView.tsx`. Le backend retourne `design.iterationsUsed` (après incrémentation) dans la réponse. Vérifier que `triggerGeneration()` dans `lib/api/designs.ts` propage bien ce champ.
+
+### Boutons d'action — Stubs pour Stories suivantes
+
+Cette story crée la structure visuelle complète. Les boutons "Ajuster" et "Commander" sont des **stubs intentionnels** :
+
+- **"Ajuster mon illustration"** : Story 3.6 — `alert()` ou disabled en attendant. L'important est que le bouton s'affiche seulement si `remainingIterations > 0`.
+- **"Commander mon poster"** : Story 4.1 (Checkout Stripe) — `alert()` ou disabled.
+
+**Ne pas implémenter la navigation vers les stories suivantes** dans cette story. Garder les `alert()` ou simplement un bouton désactivé pour la cohérence UI.
+
+### Mascotte — siana-success.svg
+
+Le dossier `/public/mascotte/` contient :
+- `siana-success.svg` ← **Utiliser ici** pour l'état de succès (révélation)
+- `siana-working.svg` ← Story 3.4 (génération en cours)
+- `siana-error.svg` ← Story 3.4 (erreur)
+- `siana-neutral.svg` ← Stories 3.1, 3.2, 3.3 (formulaire)
+
+La mascotte est **décorative** (`aria-hidden="true"`) — ne pas ajouter de texte alt descriptif.
+
+### Accessibilité (NFR-A1 à A7)
+
+- **Image du design** : Alt text descriptif avec les noms du couple — `alt="Illustration Save the Date pour ${partner1Name} et ${partner2Name}"`
+- **Bouton zoom** : `role="button"` + `tabIndex={0}` + `onKeyDown` pour accessibilité clavier + `aria-label="Voir l'illustration en plein écran"`
+- **Dialog modal** : `DialogTitle` avec `className="sr-only"` pour screen readers (dialogTitle requis par Radix Dialog, mais hidden visuellement car le contexte est clair)
+- **Compteur** : `aria-live="polite"` — la valeur peut changer dynamiquement en Story 3.6
+- **Touch targets** : Boutons `size="lg"` → ≥44px (NFR-A2)
+- **Confettis** : Purement visuels, aucun impact sur l'accessibilité (canvas external)
+
+### Fichiers à créer / modifier
+
+```
+Frontend — Créer :
+siana-memento-web/src/
+├── components/siana/
+│   ├── ResultGuard.tsx     ← CRÉER
+│   └── ResultView.tsx      ← CRÉER
+
+Frontend — Modifier :
+siana-memento-web/src/
+└── app/(public)/generate/result/
+    └── page.tsx            ← MODIFIER (remplacer stub complet)
+
+Dépendances à installer :
+siana-memento-web/
+├── package.json            ← MODIFIER (canvas-confetti + @types)
+└── package-lock.json       ← AUTO-MODIFIÉ par npm install
+```
+
+### Intelligence de Story 3.4 — À ne pas régresser
+
+**Fichiers créés/modifiés par Story 3.4 qui impactent Story 3.5 :**
+
+- `siana-memento-web/src/app/(public)/generate/result/page.tsx` → Stub actuel à **remplacer entièrement** dans Task 4 (c'était intentionnel, voir TODO dans le fichier)
+- `siana-memento-web/src/stores/useGenerationStore.ts` → `generatedImageUrl` et `iterationsUsed` déjà présents — **ne pas modifier le store**
+- `siana-memento-web/src/lib/api/designs.ts` → `triggerGeneration()` retourne `{ success: true, designId, status, iterationsUsed }` — **vérifier que `generatedImageUrl` est bien dans la réponse** (le backend retourne `generatedImageUrl` dans la response)
+
+**VÉRIFIER avant d'implémenter :** Ouvrir `siana-memento-api/app/controllers/designs_controller.ts` et confirmer que la méthode `generate()` retourne `generatedImageUrl` dans `data`. Si non, ajouter ce champ à la réponse backend (modification mineure dans `designs_controller.ts`).
+
+**VÉRIFIER aussi :** `siana-memento-web/src/lib/api/designs.ts` function `triggerGeneration()` — s'assurer que le champ `generatedImageUrl` de la réponse est retourné et que `GeneratingView.tsx` l'appelle avec le bon paramètre dans `setGenerationResult(result.iterationsUsed, result.generatedImageUrl ?? '')`.
+
+### Notes de rendu — `<img>` vs `next/image`
+
+**CRITIQUE : Utiliser `<img>` natif (pas `<Image>` next/image) pour afficher le generatedImageUrl.**
+
+Raison : `next/image` ne supporte pas les `data:` URLs (base64). Le stub Story 3.4 utilise déjà `{/* eslint-disable-next-line @next/next/no-img-element */}` pour bypasser la règle ESLint. Conserver ce pattern.
+
+Alternative MVP non retenue : upload vers Cloudinary avant affichage (trop complexe pour Story 3.5, prévu en Growth avant Story 4.2).
+
+### Project Structure Notes
+
+- Alignement avec pattern guards : `ResultGuard.tsx` suit exactement le même pattern que `GeneratingGuard.tsx`, `ConfigureGuard.tsx`, `TemplateGuard.tsx`
+- Alignement avec pattern pages : `result/page.tsx` Server Component exportant `metadata` + wrappant le Guard + View Client Components
+- `'use client'` : Uniquement sur `ResultGuard.tsx` et `ResultView.tsx`, jamais sur `page.tsx`
+- ESLint `@next/next/no-img-element` : Bypasser avec `{/* eslint-disable-next-line */}` identique au stub existant
+
+### Références
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 3.5] — User story + acceptance criteria originaux (FR14, FR15, FR16)
+- [Source: _bmad-output/implementation-artifacts/3-4-generation-ia-avec-progress-mascotte.md#Dev Notes] — Intelligence Story 3.4 (store Zustand, GeneratingView patterns, hasStarted ref pattern)
+- [Source: siana-memento-web/src/stores/useGenerationStore.ts] — Store Zustand avec generatedImageUrl, iterationsUsed, _hasHydrated, partialize
+- [Source: siana-memento-web/src/app/(public)/generate/result/page.tsx] — Stub à remplacer (TODO Story 3.5 documenté)
+- [Source: siana-memento-web/src/components/siana/GeneratingGuard.tsx] — Pattern Guard avec _hasHydrated
+- [Source: siana-memento-web/src/components/siana/GeneratingView.tsx] — Pattern hasStarted.current ref, progress bar, mascotte
+- [Source: siana-memento-web/src/components/ui/dialog.tsx] — Composant Dialog shadcn disponible
+- [Source: siana-memento-web/package.json] — Dépendances existantes (pas de canvas-confetti, doit être ajouté)
+- [Source: CLAUDE.md#Design System] — Couleurs brand (#2D4A3E, Clash Display, Satoshi)
+- [Source: _bmad-output/planning-artifacts/architecture.md] — Architecture frontend, NFR accessibilité
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md] — Moment "wow" émotionnel, confettis, fade-in
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+- Aucune erreur de debug — implémentation directe sans blocage.
+
+### Completion Notes List
+
+- ✅ Task 1 : `canvas-confetti@^1.9.4` + `@types/canvas-confetti@^1.9.0` installés dans `siana-memento-web/`
+- ✅ Task 2 : `ResultGuard.tsx` créé — vérifie `designId` + `generatedImageUrl` dans le store Zustand, redirige vers `/generate/generating` si absents. Pattern identique à `GeneratingGuard`.
+- ✅ Task 3 : `ResultView.tsx` créé — fade-in CSS `transition-opacity duration-[2000ms]` activé après 100ms, confettis canvas-confetti 3 secondes (côté gauche + droit, couleurs brand #2D4A3E #C17A6F #D4AF37), protection double déclenchement via `confettiFiredRef`, Dialog shadcn plein écran sur clic (`max-w-[95vw]`), `touch-action: pinch-zoom` sur image, compteur d'itérations `iterationsUsed/3`, mascotte `siana-success.svg`, boutons stubs disabled pour Stories 3.6 et 4.1.
+- ✅ Task 4 : `result/page.tsx` remplacé entièrement — stub Story 3.4 supprimé, Server Component avec `Metadata` + `ResultGuard` + `ResultView`.
+- ✅ Task 5 : `npx tsc --noEmit` — zéro erreur. `npx eslint` — zéro warning.
+- Note : boutons "Ajuster" et "Commander" implémentés en `disabled` (plutôt qu'`alert()`) — plus propre pour l'UX. Conforme à la spécification "ou disabled".
+- Note : `generatedImageUrl` confirmé présent dans la réponse backend (`designs_controller.ts`) et dans `triggerGeneration()` (`lib/api/designs.ts`) — aucune modification backend nécessaire.
+
+### File List
+
+**Créés :**
+- `siana-memento-web/src/components/siana/ResultGuard.tsx`
+- `siana-memento-web/src/components/siana/ResultView.tsx`
+
+**Modifiés :**
+- `siana-memento-web/src/app/(public)/generate/result/page.tsx`
+- `siana-memento-web/package.json` (canvas-confetti + @types)
+- `siana-memento-web/package-lock.json` (auto-modifié par npm install)

--- a/_bmad-output/implementation-artifacts/3-6-upload-cloudinary-et-watermark-design.md
+++ b/_bmad-output/implementation-artifacts/3-6-upload-cloudinary-et-watermark-design.md
@@ -1,0 +1,302 @@
+# Story 3.6 : Upload Cloudinary & Watermark Design Preview
+
+Status: ready-for-dev
+
+## Story
+
+En tant que système,
+je veux uploader le design généré sur Cloudinary et ne retourner au frontend qu'une preview watermarquée,
+afin que les utilisateurs ne puissent pas accéder au design pleine résolution avant paiement et que la clé base64 volumineuse disparaisse du localStorage.
+
+## Acceptance Criteria
+
+1. **Given** la génération Gemini terminée avec succès **When** le backend obtient le PNG base64 **Then** il l'uploade sur Cloudinary (dossier `designs/`, `public_id` = `design-{designId}`) avant de répondre au frontend
+
+2. **Given** l'upload Cloudinary réussi **When** le backend construit la réponse **Then** il retourne un `previewUrl` watermarqué via transformation Cloudinary (redimensionné à 1000px, watermark texte "Siana Memento" centré semi-transparent) — jamais le base64 ni l'URL originale full-res
+
+3. **Given** la réponse backend reçue **When** `GeneratingView.tsx` appelle `setGenerationResult()` **Then** le store Zustand stocke le `previewUrl` (URL https Cloudinary) dans `generatedImageUrl` — le localStorage ne contient plus aucun base64
+
+4. **Given** l'utilisateur sur `/generate/result` **When** la page s'affiche **Then** `ResultView.tsx` affiche la preview watermarquée via l'URL Cloudinary (aucune modification de `ResultView` nécessaire — il lit déjà `generatedImageUrl` du store)
+
+5. **Given** l'upload Cloudinary réussi **When** on inspecte la table `designs` en base **Then** les champs `cloudinary_public_id` et `preview_url` sont renseignés — le full-res propre est accessible uniquement côté serveur via l'URL Cloudinary originale (pour Story 4.2 delivery email)
+
+6. **Given** l'upload Cloudinary qui échoue **When** après 3 tentatives (retry logic existant) **Then** le backend retourne une erreur 500 et la génération est marquée en échec — même comportement que l'erreur Gemini
+
+7. **Given** un design uploadé sur Cloudinary **When** le cron RGPD de Story 3.8 s'exécute après 7 jours (designs non achetés) ou 7 jours post-achat **Then** la suppression Cloudinary utilise le `cloudinary_public_id` stocké en base (Story 3.8 doit intégrer cette dépendance)
+
+## Tasks / Subtasks
+
+### Backend — Migration base de données
+
+- [ ] Task 1 : Créer une migration AdonisJS pour ajouter les champs Cloudinary sur la table `designs`
+  - [ ] Depuis `siana-memento-api/` :
+    ```bash
+    node ace make:migration add_cloudinary_fields_to_designs
+    ```
+  - [ ] Contenu de la migration :
+    ```typescript
+    import { BaseSchema } from '@adonisjs/lucid/schema'
+
+    export default class extends BaseSchema {
+      protected tableName = 'designs'
+
+      async up() {
+        this.schema.alterTable(this.tableName, (table) => {
+          table.string('cloudinary_public_id').nullable()
+          table.string('preview_url', 1024).nullable()
+        })
+      }
+
+      async down() {
+        this.schema.alterTable(this.tableName, (table) => {
+          table.dropColumn('cloudinary_public_id')
+          table.dropColumn('preview_url')
+        })
+      }
+    }
+    ```
+  - [ ] Exécuter : `node ace migration:run`
+
+### Backend — Service Cloudinary
+
+- [ ] Task 2 : Créer `siana-memento-api/app/services/cloudinary_service.ts` (AC: #1, #2, #5, #6)
+  - [ ] Installer le SDK Cloudinary :
+    ```bash
+    npm install cloudinary
+    ```
+  - [ ] Implémentation :
+    ```typescript
+    import { v2 as cloudinary } from 'cloudinary'
+    import env from '#start/env'
+
+    cloudinary.config({
+      cloud_name: env.get('CLOUDINARY_CLOUD_NAME'),
+      api_key: env.get('CLOUDINARY_API_KEY'),
+      api_secret: env.get('CLOUDINARY_API_SECRET'),
+    })
+
+    const WATERMARK_TRANSFORMATION =
+      'c_scale,w_1000/l_text:Arial_55_bold:Siana%20Memento,co_rgb:FFFFFF,o_40,g_center'
+
+    export async function uploadDesign(
+      base64DataUrl: string,
+      designId: number
+    ): Promise<{ publicId: string; previewUrl: string }> {
+      const result = await cloudinary.uploader.upload(base64DataUrl, {
+        folder: 'designs',
+        public_id: `design-${designId}`,
+        overwrite: true,
+        resource_type: 'image',
+      })
+
+      // Construire l'URL preview watermarquée
+      const previewUrl = result.secure_url.replace(
+        '/upload/',
+        `/upload/${WATERMARK_TRANSFORMATION}/`
+      )
+
+      return {
+        publicId: result.public_id,
+        previewUrl,
+      }
+    }
+
+    export async function deleteDesign(publicId: string): Promise<void> {
+      await cloudinary.uploader.destroy(publicId, { resource_type: 'image' })
+    }
+    ```
+  - [ ] Ajouter les variables d'environnement dans `.env` et `.env.example` :
+    ```
+    CLOUDINARY_CLOUD_NAME=
+    CLOUDINARY_API_KEY=
+    CLOUDINARY_API_SECRET=
+    ```
+  - [ ] Valider que `start/env.ts` expose les 3 variables Cloudinary
+
+### Backend — Contrôleur designs
+
+- [ ] Task 3 : Modifier `siana-memento-api/app/controllers/designs_controller.ts` (AC: #1, #2, #5, #6)
+  - [ ] Importer `uploadDesign` depuis `cloudinary_service`
+  - [ ] Dans la méthode `generate()`, après réception du base64 Gemini et avant la réponse :
+    ```typescript
+    // Upload vers Cloudinary
+    const { publicId, previewUrl } = await uploadDesign(generatedImageBase64, design.id)
+
+    // Persister dans la base
+    design.cloudinaryPublicId = publicId
+    design.previewUrl = previewUrl
+    await design.save()
+
+    // Retourner previewUrl au lieu du base64
+    return response.ok({
+      success: true,
+      designId: design.id,
+      status: design.status,
+      iterationsUsed: design.iterationsUsed,
+      previewUrl,                   // ← nouveau champ
+      // generatedImageUrl supprimé ← ne plus retourner le base64
+    })
+    ```
+  - [ ] Mettre à jour le modèle Lucid `Design` pour inclure `cloudinaryPublicId` et `previewUrl` dans les colonnes
+
+### Frontend — Type de réponse API
+
+- [ ] Task 4 : Mettre à jour `siana-memento-web/src/lib/api/designs.ts` (AC: #3)
+  - [ ] Remplacer `generatedImageUrl?: string` par `previewUrl?: string` dans le type de réponse de `triggerGeneration()`
+  - [ ] S'assurer que la valeur retournée par `triggerGeneration()` inclut `previewUrl`
+
+### Frontend — Store Zustand
+
+- [ ] Task 5 : Mettre à jour `siana-memento-web/src/stores/useGenerationStore.ts` (AC: #3)
+  - [ ] **Aucun renommage de champ** — `generatedImageUrl` reste le nom du champ dans le store (il stocke désormais une URL Cloudinary https au lieu d'un base64 — changement transparent pour `ResultView`)
+  - [ ] Vérifier que `partialize` dans la config `persist` inclut bien `generatedImageUrl` (déjà le cas)
+
+### Frontend — GeneratingView
+
+- [ ] Task 6 : Mettre à jour `siana-memento-web/src/components/siana/GeneratingView.tsx` (AC: #3)
+  - [ ] Changer l'appel `setGenerationResult` pour utiliser `result.previewUrl` au lieu de `result.generatedImageUrl` :
+    ```typescript
+    // Avant
+    setGenerationResult(result.iterationsUsed, result.generatedImageUrl ?? '')
+    // Après
+    setGenerationResult(result.iterationsUsed, result.previewUrl ?? '')
+    ```
+
+### Vérification
+
+- [ ] Task 7 : Tests de non-régression
+  - [ ] `node ace migration:run` sans erreur
+  - [ ] Génération complète end-to-end : l'image affichée sur `/generate/result` est bien une URL `res.cloudinary.com` avec transformation watermark visible
+  - [ ] Le localStorage ne contient plus aucun base64 (vérifier dans DevTools → Application → Local Storage)
+  - [ ] Right-click sur la preview → "Ouvrir l'image dans un nouvel onglet" → l'URL est une URL Cloudinary publique (acceptable pour le MVP, le watermark est présent)
+  - [ ] `npx tsc --noEmit` depuis `siana-memento-web/` — zéro erreur
+  - [ ] `node ace build` depuis `siana-memento-api/` — zéro erreur TypeScript
+
+## Dev Notes
+
+### Pourquoi cette story existe
+
+Story 3.5 implémentait le résultat en base64 stocké dans localStorage (`siana-generation-store`). Cette approche posait deux problèmes :
+
+1. **Sécurité :** N'importe qui avec DevTools pouvait extraire le PNG pleine résolution depuis le localStorage avant paiement
+2. **Performance :** Un base64 de 5-15MB dans le localStorage ralentit la (ré)hydratation Zustand et consomme le quota localStorage (5MB max sur certains navigateurs)
+
+### Architecture Cloudinary retenue
+
+```
+Gemini API → base64 PNG 3000×3000px
+    ↓
+CloudinaryService.uploadDesign()
+    ↓
+Cloudinary stocke le PNG original (full-res, propre)
+    ↓
+Backend construit previewUrl = URL originale + transformation watermark + scale 1000px
+    ↓
+Frontend reçoit uniquement previewUrl
+    ↓
+localStorage stocke une URL https (< 200 octets au lieu de 15MB)
+    ↓
+Story 4.2 (delivery email) : backend récupère cloudinaryPublicId → génère URL full-res propre → envoie par email
+```
+
+### Transformation Cloudinary — Détail
+
+```
+https://res.cloudinary.com/{cloud}/image/upload/
+  c_scale,w_1000/
+  l_text:Arial_55_bold:Siana%20Memento,co_rgb:FFFFFF,o_40,g_center/
+  designs/design-42.png
+```
+
+- `c_scale,w_1000` : redimensionner à 1000px de large (preview, pas besoin du 3000px)
+- `l_text:Arial_55_bold:Siana%20Memento` : overlay texte "Siana Memento"
+- `co_rgb:FFFFFF` : couleur blanche
+- `o_40` : opacité 40% (visible mais ne cache pas l'illustration)
+- `g_center` : centré sur l'image
+
+**Alternative Growth :** Uploader un vrai logo SVG Siana en tant que `named transformation` Cloudinary pour un watermark plus professionnel. Pour le MVP, le texte est suffisant.
+
+### Variables d'environnement requises
+
+Ajouter dans Railway (production) et `.env.local` (dev) :
+```
+CLOUDINARY_CLOUD_NAME=   # trouvé dans le dashboard Cloudinary
+CLOUDINARY_API_KEY=      # Settings → API Keys
+CLOUDINARY_API_SECRET=   # Settings → API Keys (sensible)
+```
+
+Cloudinary Free Plan : 25 crédits/mois inclus (1 crédit ≈ 1 transformation ou 1 upload). Amplement suffisant pour le MVP.
+
+### Modèle Lucid — Colonnes à ajouter
+
+Dans `siana-memento-api/app/models/design.ts`, ajouter :
+```typescript
+@column()
+declare cloudinaryPublicId: string | null
+
+@column()
+declare previewUrl: string | null
+```
+
+### Impact sur Story 3.8 (Cron RGPD)
+
+Story 3.8 devra maintenant supprimer deux types d'assets Cloudinary :
+- **Photos** (existant) : `photos/` → suppression J+7 depuis upload
+- **Designs** (nouveau) : `designs/` → suppression J+7 depuis génération (non achetés) ou J+7 depuis achat (achetés)
+
+Story 3.8 peut utiliser `deleteDesign(design.cloudinaryPublicId)` depuis `cloudinary_service.ts`.
+
+### Impact sur Story 4.2 (Delivery Email)
+
+Story 4.2 doit envoyer le design full-res par email. Deux options :
+- **Option A (simple) :** URL Cloudinary sans transformation (originale) → annexée à l'email. L'URL est publique mais non devinables (public_id aléatoire).
+- **Option B (sécurisée) :** URL signée Cloudinary (expiration 1h) générée au moment de l'envoi email.
+
+Recommandation : Option A pour MVP, Option B en Growth. À décider en Story 4.2.
+
+### Latence — Point de vigilance
+
+L'upload Cloudinary ajoute du temps au flux de génération. Estimation :
+- PNG 3000×3000 = ~5-15MB (base64 = ~7-20MB)
+- Upload depuis Railway → Cloudinary : ~2-5s (dépend de la bande passante Railway)
+
+Si la génération Gemini + upload dépasse les 30s (NFR-P1), deux options :
+1. Upload en arrière-plan (async) → retourner une URL temporaire ou polling
+2. Réduire la résolution du PNG uploadé sur Cloudinary (ex: 1500px → 3-4s upload)
+
+À mesurer lors de l'implémentation.
+
+### Fichiers à créer / modifier
+
+```
+Backend — Créer :
+siana-memento-api/
+├── app/services/cloudinary_service.ts     ← CRÉER
+└── database/migrations/YYYYMMDD_add_cloudinary_fields_to_designs.ts ← CRÉER
+
+Backend — Modifier :
+siana-memento-api/
+├── app/controllers/designs_controller.ts  ← MODIFIER
+├── app/models/design.ts                   ← MODIFIER (ajouter colonnes)
+├── start/env.ts                           ← MODIFIER (ajouter CLOUDINARY_*)
+└── .env / .env.example                    ← MODIFIER
+
+Frontend — Modifier :
+siana-memento-web/src/
+├── lib/api/designs.ts                     ← MODIFIER (type réponse)
+├── stores/useGenerationStore.ts           ← VÉRIFIER (aucun changement prévu)
+└── components/siana/GeneratingView.tsx    ← MODIFIER (previewUrl vs generatedImageUrl)
+```
+
+### Aucun changement sur ResultView ni ResultGuard
+
+`ResultView.tsx` et `ResultGuard.tsx` (Story 3.5) lisent `generatedImageUrl` depuis le store. Comme le store stocke désormais une URL Cloudinary à la place du base64, **aucune modification de ces fichiers n'est nécessaire**. La substitution est transparente.
+
+### Références
+
+- [Source: conversation design — 2026-03-03] — Décision d'utiliser Cloudinary watermark suite au test de la Story 3.5
+- [Source: _bmad-output/planning-artifacts/architecture.md] — Cloudinary déjà dans la stack pour les photos
+- [Source: _bmad-output/implementation-artifacts/3-5-revelation-du-design-avec-effet-wow.md] — ResultView utilise `generatedImageUrl` du store
+- [Source: _bmad-output/implementation-artifacts/3-4-generation-ia-avec-progress-mascotte.md] — GeneratingView + setGenerationResult pattern
+- [Source: https://cloudinary.com/documentation/node_integration] — SDK Node.js Cloudinary v2
+- [Source: https://cloudinary.com/documentation/image_transformations] — Transformations URL Cloudinary

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -60,9 +60,10 @@ development_status:
   3-2-galerie-de-selection-de-template: done
   3-3-form-conversationnel-enrichi-avec-preview-texte: done
   3-4-generation-ia-avec-progress-mascotte: done
-  3-5-revelation-du-design-avec-effet-wow: review
-  3-6-iterations-et-feedback-simple: backlog
-  3-7-cron-rgpd-suppression-automatique-des-photos: backlog
+  3-5-revelation-du-design-avec-effet-wow: done
+  3-6-upload-cloudinary-et-watermark-design: ready-for-dev
+  3-7-iterations-et-feedback-simple: backlog
+  3-8-cron-rgpd-suppression-automatique-des-photos: backlog
   epic-3-retrospective: optional
 
   epic-4: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -60,7 +60,7 @@ development_status:
   3-2-galerie-de-selection-de-template: done
   3-3-form-conversationnel-enrichi-avec-preview-texte: done
   3-4-generation-ia-avec-progress-mascotte: done
-  3-5-revelation-du-design-avec-effet-wow: backlog
+  3-5-revelation-du-design-avec-effet-wow: review
   3-6-iterations-et-feedback-simple: backlog
   3-7-cron-rgpd-suppression-automatique-des-photos: backlog
   epic-3-retrospective: optional

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -469,9 +469,9 @@ afin de finaliser mon achat sans avoir été bloqué par un login wall dès l'ar
 
 ### Epic 3 : Création & Génération de Design IA
 
-Les utilisateurs peuvent uploader leurs photos, configurer leur Save the Date via un form conversationnel enrichi avec preview texte, choisir un style parmi 5 templates, lancer la génération IA avec progress mascotte, prévisualiser le résultat avec révélation + confettis, et itérer jusqu'à 3 fois. Les photos sont automatiquement supprimées après 7 jours (RGPD).
+Les utilisateurs peuvent uploader leurs photos, configurer leur Save the Date via un form conversationnel enrichi avec preview texte, choisir un style parmi 5 templates, lancer la génération IA avec progress mascotte, prévisualiser le résultat via une preview watermarquée Cloudinary avec révélation + confettis, et itérer jusqu'à 3 fois. Les photos et designs sont automatiquement supprimés après 7 jours (RGPD).
 
-FRs couverts : FR9, FR10, FR11, FR12, FR13, FR14, FR15, FR16, FR17, FR18, FR23 (simplifié mascotte), FR31 (cron RGPD photos), FR40, FR41, FR43, FR44
+FRs couverts : FR9, FR10, FR11, FR12, FR13, FR14, FR15, FR16, FR17, FR18, FR23 (simplifié mascotte), FR31 (cron RGPD photos + designs), FR40, FR41, FR43, FR44
 Growth documentés : FR19, FR20, FR21, FR22 (feedback guidé IA-powered — TODO Growth)
 NFRs clés : NFR-P1, NFR-P3, NFR-P4, NFR-P5, NFR-P6, NFR-SC1, NFR-SC6, NFR-I1, NFR-I4, NFR-I5, NFR-I7, NFR-A1-A7, NFR-S5, NFR-S9
 
@@ -603,7 +603,33 @@ afin de vivre le moment émotionnel fort qui est au cœur de l'expérience Siana
 
 ---
 
-### Story 3.6 : Itérations et Feedback Simple
+### Story 3.6 : Upload Cloudinary & Watermark Design Preview
+
+En tant que système,
+je veux uploader le design généré sur Cloudinary et ne retourner au frontend qu'une preview watermarquée,
+afin que les utilisateurs ne puissent pas accéder au design pleine résolution avant paiement et que le base64 volumineuse disparaisse du localStorage.
+
+**Acceptance Criteria:**
+
+**Given** la génération Gemini terminée avec succès
+**When** le backend obtient le PNG base64
+**Then** il l'uploade sur Cloudinary (dossier `designs/`) et retourne un `previewUrl` watermarqué (redimensionné 1000px, watermark texte centré semi-transparent) — jamais le base64 ni l'URL full-res originale
+
+**Given** l'upload Cloudinary réussi
+**When** on inspecte la table `designs`
+**Then** les champs `cloudinary_public_id` et `preview_url` sont renseignés — le full-res propre est accessible uniquement côté serveur (pour Story 4.2 delivery email)
+
+**Given** le localStorage de l'utilisateur
+**When** il inspecte `siana-generation-store`
+**Then** `generatedImageUrl` contient une URL `https://res.cloudinary.com/...` — aucun base64 en localStorage
+
+**Given** l'upload Cloudinary qui échoue
+**When** après 3 tentatives
+**Then** le backend retourne une erreur 500 et la génération est marquée en échec
+
+---
+
+### Story 3.7 : Itérations et Feedback Simple
 
 En tant qu'utilisateur non satisfait du premier résultat,
 je veux ajuster ma demande et regénérer,
@@ -629,10 +655,10 @@ afin d'obtenir une illustration plus proche de mes attentes dans la limite de 3 
 
 ---
 
-### Story 3.7 : Cron RGPD — Suppression Automatique des Photos
+### Story 3.8 : Cron RGPD — Suppression Automatique des Photos & Designs
 
 En tant que système,
-je veux supprimer automatiquement les photos des utilisateurs après 7 jours,
+je veux supprimer automatiquement les photos et designs des utilisateurs après 7 jours,
 afin d'être conforme au RGPD et à la politique de confidentialité affichée.
 
 **Acceptance Criteria:**
@@ -640,6 +666,14 @@ afin d'être conforme au RGPD et à la politique de confidentialité affichée.
 **Given** une photo uploadée sur Cloudinary
 **When** 7 jours se sont écoulés depuis l'upload
 **Then** la photo est automatiquement supprimée de Cloudinary via un cron job quotidien (FR31, NFR-S5)
+
+**Given** un design généré (non acheté) stocké sur Cloudinary
+**When** 7 jours se sont écoulés depuis la génération
+**Then** le design est automatiquement supprimé de Cloudinary via le même cron job (utilise `cloudinary_public_id` de la table `designs`)
+
+**Given** un design acheté stocké sur Cloudinary
+**When** 7 jours se sont écoulés depuis la date d'achat
+**Then** le design est automatiquement supprimé de Cloudinary (dépendance Story 4.1 pour `purchased_at`)
 
 **Given** le cron job exécuté
 **When** j'inspecte les logs backend

--- a/siana-memento-web/package-lock.json
+++ b/siana-memento-web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@vercel/analytics": "^1.6.1",
+        "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -28,6 +29,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3879,6 +3881,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5149,6 +5157,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/siana-memento-web/package.json
+++ b/siana-memento-web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@vercel/analytics": "^1.6.1",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/siana-memento-web/src/app/(public)/generate/result/page.tsx
+++ b/siana-memento-web/src/app/(public)/generate/result/page.tsx
@@ -1,91 +1,18 @@
-'use client'
+import type { Metadata } from 'next'
+import ResultGuard from '@/components/siana/ResultGuard'
+import ResultView from '@/components/siana/ResultView'
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import Image from 'next/image'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { useGenerationStore } from '@/stores/useGenerationStore'
+export const metadata: Metadata = {
+  title: 'Votre Save the Date — Siana Memento',
+}
 
-/**
- * Page résultat temporaire — Story 3.4
- * ─────────────────────────────────────
- * Affiche l'image générée stockée dans le Zustand store.
- * Cette page sera remplacée par la version complète lors de la Story 3.5
- * (effet "révélation" + confetti + partage + options d'itération).
- *
- * TODO Story 3.5 : Remplacer par ResultView avec l'effet "wow" complet.
- */
 export default function ResultPage() {
-  const router = useRouter()
-  const { generatedImageUrl, partner1Name, partner2Name, _hasHydrated, designId } =
-    useGenerationStore()
-  const [imageError, setImageError] = useState(false)
-
-  useEffect(() => {
-    if (!_hasHydrated) return
-    if (!designId || !generatedImageUrl) {
-      router.replace('/generate/generating')
-    }
-  }, [_hasHydrated, designId, generatedImageUrl, router])
-
-  if (!_hasHydrated || !generatedImageUrl) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-muted-foreground">Chargement du résultat…</p>
-      </div>
-    )
-  }
-
   return (
-    <main className="flex min-h-screen flex-col items-center px-4 py-10">
-      <div className="w-full max-w-lg flex flex-col items-center gap-6">
-        {/* En-tête */}
-        <div className="text-center">
-          <h1 className="text-3xl font-bold">Votre Save the Date est prêt ! 🎉</h1>
-          {partner1Name && partner2Name && (
-            <p className="mt-2 text-muted-foreground">
-              {partner1Name} &amp; {partner2Name}
-            </p>
-          )}
-        </div>
-
-        {/* Image générée */}
-        {!imageError ? (
-          <div className="relative w-full overflow-hidden rounded-2xl shadow-2xl">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={generatedImageUrl}
-              alt={`Illustration Save the Date pour ${partner1Name ?? ''} et ${partner2Name ?? ''}`}
-              className="w-full h-auto object-contain"
-              onError={() => setImageError(true)}
-            />
-          </div>
-        ) : (
-          <div className="flex w-full h-64 items-center justify-center rounded-2xl bg-muted">
-            <p className="text-sm text-muted-foreground">
-              Impossible d&apos;afficher l&apos;image générée.
-            </p>
-          </div>
-        )}
-
-        {/* Note temporaire */}
-        <div className="rounded-xl border border-dashed border-muted-foreground/30 bg-muted/40 px-4 py-3 text-center">
-          <p className="text-xs text-muted-foreground">
-            ✨ Page de résultat temporaire — La version finale (Story 3.5) inclura un effet de
-            révélation, des confettis et des options d&apos;itération.
-          </p>
-        </div>
-
-        {/* Actions */}
-        <div className="flex w-full flex-col gap-3">
-          <Button asChild size="lg" className="w-full font-semibold">
-            <Link href="/generate/generating">Générer une nouvelle version</Link>
-          </Button>
-          <Button asChild variant="outline" size="lg" className="w-full">
-            <Link href="/">Retour à l&apos;accueil</Link>
-          </Button>
-        </div>
+    <main className="flex min-h-screen flex-col items-center justify-start px-4 py-8">
+      <div className="w-full max-w-lg">
+        <ResultGuard>
+          <ResultView />
+        </ResultGuard>
       </div>
     </main>
   )

--- a/siana-memento-web/src/components/siana/ResultGuard.tsx
+++ b/siana-memento-web/src/components/siana/ResultGuard.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useGenerationStore } from '@/stores/useGenerationStore'
+
+interface ResultGuardProps {
+  children: React.ReactNode
+}
+
+export default function ResultGuard({ children }: ResultGuardProps) {
+  const router = useRouter()
+  const { designId, generatedImageUrl, _hasHydrated } = useGenerationStore()
+
+  useEffect(() => {
+    if (!_hasHydrated) return
+    if (!designId || !generatedImageUrl) {
+      router.replace('/generate/generating')
+    }
+  }, [_hasHydrated, designId, generatedImageUrl, router])
+
+  if (!_hasHydrated || !designId || !generatedImageUrl) return null
+
+  return <>{children}</>
+}

--- a/siana-memento-web/src/components/siana/ResultView.tsx
+++ b/siana-memento-web/src/components/siana/ResultView.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useGenerationStore } from '@/stores/useGenerationStore'
+import confetti from 'canvas-confetti'
+
+const MAX_ITERATIONS = 3
+
+export default function ResultView() {
+  const { generatedImageUrl, partner1Name, partner2Name, iterationsUsed } = useGenerationStore()
+  const [isRevealed, setIsRevealed] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const confettiFiredRef = useRef(false)
+
+  // Fade-in de l'image + lancement des confettis
+  useEffect(() => {
+    // Petite pause pour laisser le DOM se stabiliser au montage
+    const revealTimer = setTimeout(() => {
+      setIsRevealed(true)
+
+      // Lancer les confettis une seule fois (protection React Strict Mode double mount)
+      if (!confettiFiredRef.current) {
+        confettiFiredRef.current = true
+        const end = Date.now() + 3000 // 3 secondes de confettis
+
+        const launchConfetti = () => {
+          confetti({
+            particleCount: 3,
+            angle: 60,
+            spread: 55,
+            origin: { x: 0 },
+            colors: ['#2D4A3E', '#C17A6F', '#D4AF37'],
+          })
+          confetti({
+            particleCount: 3,
+            angle: 120,
+            spread: 55,
+            origin: { x: 1 },
+            colors: ['#2D4A3E', '#C17A6F', '#D4AF37'],
+          })
+          if (Date.now() < end) {
+            requestAnimationFrame(launchConfetti)
+          }
+        }
+
+        // Démarrer les confettis après 300ms (image à ~15% du fade-in)
+        setTimeout(launchConfetti, 300)
+      }
+    }, 100)
+
+    return () => clearTimeout(revealTimer)
+  }, [])
+
+  const remainingIterations = MAX_ITERATIONS - iterationsUsed
+  const iterationLabel =
+    remainingIterations > 0
+      ? `Itération ${iterationsUsed}/${MAX_ITERATIONS} — ${remainingIterations} itération${remainingIterations > 1 ? 's' : ''} restante${remainingIterations > 1 ? 's' : ''} incluse${remainingIterations > 1 ? 's' : ''}`
+      : `Itération ${iterationsUsed}/${MAX_ITERATIONS} — Aucune itération restante`
+
+  const altText = `Illustration Save the Date pour ${partner1Name ?? ''} et ${partner2Name ?? ''}`
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-8">
+      {/* Mascotte + message de félicitations */}
+      <div className="flex flex-col items-center gap-3">
+        <Image
+          src="/mascotte/siana-success.svg"
+          alt=""
+          aria-hidden="true"
+          width={72}
+          height={72}
+        />
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Votre Save the Date est prêt !</h1>
+          {partner1Name && partner2Name && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {partner1Name} &amp; {partner2Name}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Illustration avec fade-in et comportement zoom */}
+      <div
+        className={[
+          'w-full overflow-hidden rounded-2xl shadow-2xl cursor-zoom-in',
+          'transition-opacity duration-[2000ms] ease-in-out',
+          isRevealed ? 'opacity-100' : 'opacity-0',
+        ].join(' ')}
+        style={{ touchAction: 'pinch-zoom' }}
+        onClick={() => setIsModalOpen(true)}
+        onKeyDown={(e) => e.key === 'Enter' && setIsModalOpen(true)}
+        role="button"
+        tabIndex={0}
+        aria-label="Voir l'illustration en plein écran"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={generatedImageUrl!}
+          alt={altText}
+          className="w-full h-auto object-contain"
+        />
+      </div>
+
+      {/* Compteur d'itérations */}
+      <p className="text-sm text-muted-foreground text-center" aria-live="polite">
+        {iterationLabel}
+      </p>
+
+      {/* Actions */}
+      <div className="flex w-full flex-col gap-3">
+        {remainingIterations > 0 ? (
+          <Button
+            size="lg"
+            variant="outline"
+            className="w-full font-semibold"
+            disabled
+            title="Disponible en Story 3.6"
+          >
+            Ajuster mon illustration
+          </Button>
+        ) : (
+          <Button size="lg" variant="outline" className="w-full" disabled>
+            Limite de 3 itérations atteinte
+          </Button>
+        )}
+        <Button
+          size="lg"
+          className="w-full font-semibold"
+          disabled
+          title="Disponible en Story 4.1"
+        >
+          Commander mon poster — 19,90 €
+        </Button>
+      </div>
+
+      {/* Dialog plein écran pour zoom */}
+      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+        <DialogContent
+          className="max-w-[95vw] max-h-[95vh] p-2 overflow-auto"
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="sr-only">
+            Illustration Save the Date — Vue plein écran
+          </DialogTitle>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={generatedImageUrl!}
+            alt={altText}
+            className="w-full h-auto object-contain"
+            style={{ touchAction: 'pinch-zoom' }}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/siana-memento-web/src/components/siana/ResultView.tsx
+++ b/siana-memento-web/src/components/siana/ResultView.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -18,6 +19,7 @@ export default function ResultView() {
   const [isRevealed, setIsRevealed] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const confettiFiredRef = useRef(false)
+  const confettiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Fade-in de l'image + lancement des confettis
   useEffect(() => {
@@ -51,11 +53,14 @@ export default function ResultView() {
         }
 
         // Démarrer les confettis après 300ms (image à ~15% du fade-in)
-        setTimeout(launchConfetti, 300)
+        confettiTimerRef.current = setTimeout(launchConfetti, 300)
       }
     }, 100)
 
-    return () => clearTimeout(revealTimer)
+    return () => {
+      clearTimeout(revealTimer)
+      if (confettiTimerRef.current) clearTimeout(confettiTimerRef.current)
+    }
   }, [])
 
   const remainingIterations = MAX_ITERATIONS - iterationsUsed
@@ -96,7 +101,7 @@ export default function ResultView() {
         ].join(' ')}
         style={{ touchAction: 'pinch-zoom' }}
         onClick={() => setIsModalOpen(true)}
-        onKeyDown={(e) => e.key === 'Enter' && setIsModalOpen(true)}
+        onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setIsModalOpen(true)}
         role="button"
         tabIndex={0}
         aria-label="Voir l'illustration en plein écran"
@@ -157,6 +162,11 @@ export default function ResultView() {
             className="w-full h-auto object-contain"
             style={{ touchAction: 'pinch-zoom' }}
           />
+          <DialogClose asChild>
+            <Button variant="outline" className="mt-2 w-full" aria-label="Fermer la vue plein écran">
+              Fermer
+            </Button>
+          </DialogClose>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Résumé

- Révélation animée du design généré via fade-in CSS 2s + confettis canvas-confetti 3s (couleurs brand)
- Modal plein écran au clic sur l'illustration avec bouton "Fermer" explicite
- Pinch-to-zoom natif mobile via `touch-action: pinch-zoom`
- Compteur d'itérations (ex: "Itération 1/3 — 2 itérations restantes incluses")
- `ResultGuard` : redirection automatique vers `/generate/generating` si store vide
- Mascotte `siana-success.svg` + message de félicitations

## Corrections post-review

- Ajout du bouton `DialogClose` "Fermer" manquant dans la modal (AC#2)
- Gestion de la touche Espace sur `role="button"` (WCAG)
- Cleanup du `setTimeout` confettis interne pour éviter un déclenchement après unmount

## Contenu bonus

- Ajout de la story 3-6 (Upload Cloudinary & Watermark Design Preview) suite à l'analyse sécurité de la session de test
- Renommage 3-6→3-7 et 3-7→3-8 dans le sprint plan

## Plan de test

- [ ] Injecter le store via `localStorage.setItem('siana-generation-store', ...)` et naviguer vers `/generate/result`
- [ ] Vérifier fade-in 2s + confettis 3s des deux côtés
- [ ] Cliquer sur l'image → modal s'ouvre, bouton "Fermer" présent, Escape ferme aussi
- [ ] Tab sur l'image → Enter et Espace ouvrent la modal
- [ ] Vider le store → redirection automatique vers `/generate/generating`
- [ ] Vérifier compteur selon `iterationsUsed` (1/3, 2/3, 3/3)